### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "pug": "^2.0.0-beta6",
     "push-notify": "habitrpg/push-notify#v1.2.0",
     "pusher": "^1.3.0",
-    "request": "~2.72.0",
+    "request": "~2.74.0",
     "rimraf": "^2.4.3",
     "run-sequence": "^1.1.4",
     "s3-upload-stream": "^1.0.6",


### PR DESCRIPTION
habitica is currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722). 

Vulnerable module: `tough-cookie`
Introduced through: `request`

This PR fixes the ReDOS vulnerability by upgrading `request` to version 2.74.0

Check out the [Snyk test report](https://snyk.io/test/github/HabitRPG/habitica) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
- get alerts if newly disclosed vulnerabilities affect this repo in the future. 
- generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team
